### PR TITLE
Runnable graph extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently, there are no CFG edges.
 
 ### Graph extraction
 * Go to `src/data_preparation/scripts`
+* Install dependencies with `pip install -r requirements.txt`
 * Run `python -m graph_generator.run -i {input_dir} -o {output_dir}`
 * You can select output format with `-f {format}`. Currently, `dot` and `jsonl_gz` are supported
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
-# Typilus
+# Typilus + Graph generation
+
+On top of Typilus, this repository can be used to generate augmented ASTs that were used in Typilus.
+
+## Graph generation
+
+### Graph structure
+
+The graphs contain the following edges:
+* `CHILD` &ndash; AST edges
+* `NEXT` &ndash; edges connecting subsequent tokens in code
+* `NEXT_USE` &ndash; next usage of a variable
+* `LAST_LEXICAL_USE` &ndash; previous usage of a variable
+* `OCCURRENCES_OF` &ndash; edges between occurrences of the same variable 
+* `SUBTOKEN_OF` &ndash; edges from subtokens to their origin
+* `COMPUTED_FROM` &ndash; edges that point to the origins of a variable
+* `RETURNS_TO` &ndash; edges from return/yield statements to the function definition
+
+Currently, there are no CFG edges.
+
+### Graph extraction
+* Go to `src/data_preparation/scripts`
+* Run `python -m graph_generator.run -i {input_dir} -o {output_dir}`
+* You can select output format with `-f {format}`. Currently, `dot` and `jsonl_gz` are supported
+
+## [Original Typilus](https://github.com/typilus/typilus)
 
 A deep learning algorithm for predicting types in Python. Please find a preprint [here](https://arxiv.org/abs/2004.10657).
 

--- a/src/data_preparation/scripts/graph_generator/run.py
+++ b/src/data_preparation/scripts/graph_generator/run.py
@@ -1,0 +1,88 @@
+import os
+from argparse import ArgumentParser, Namespace
+from glob import iglob
+from typing import List, Dict, Iterable, Tuple
+
+from dpu_utils.utils import ChunkWriter
+from tqdm import tqdm
+
+from graph_generator.graphgenerator import AstGraphGenerator
+from graph_generator.type_lattice_generator import TypeLatticeGenerator
+
+
+def get_files(root: str):
+    return [fname for fname in iglob(os.path.join(root, '**/*.py'), recursive=True) if not os.path.isdir(fname)]
+
+
+def generate_graphs_for_files(
+        fnames: List[str], skipped_files: List[str], errored_files: List[Tuple[str, Exception]],
+        lattice: TypeLatticeGenerator
+) -> Iterable[Tuple[AstGraphGenerator, Dict, str]]:
+    for fname in fnames:
+        try:
+            with open(fname) as f:
+                generator = AstGraphGenerator(f.read(), lattice)
+                graph = generator.build()
+                yield generator, graph, fname
+        except (SyntaxError, UnicodeDecodeError):
+            skipped_files.append(fname)
+        except Exception as e:
+            errored_files.append((fname, e))
+
+
+def run(args: Namespace):
+    filenames = get_files(args.input)
+    lattice = TypeLatticeGenerator(args.type_rules)
+    skipped_files, errored_files = [], []
+    graph_generator = generate_graphs_for_files(filenames, skipped_files, errored_files, lattice)
+
+    os.makedirs(args.output, exist_ok=True)
+
+    if args.format == "dot":
+        for i, (generator, graph, fname) in tqdm(enumerate(graph_generator)):
+            generator.to_dot(os.path.join(args.output, f"graph_{i}.dot"), initial_comment=fname)
+    elif args.format == "jsonl_gz":
+        with ChunkWriter(out_folder=args.output, file_prefix='all-graphs',
+                         max_chunk_size=5000, file_suffix='.jsonl.gz') as writer:
+            for i, (generator, graph, fname) in tqdm(enumerate(graph_generator)):
+                graph['filename'] = fname
+                writer.add(graph)
+    else:
+        raise ValueError(f'File format {args.format} is not supported')
+    print(f'Finished parsing. Skipped {len(skipped_files)}, failed on {len(errored_files)}')
+    if len(skipped_files) > 0:
+        print('Skipped:')
+        for fname in skipped_files:
+            print(fname)
+    if len(errored_files) > 0:
+        print('Failed on:')
+        for fname, e in errored_files:
+            print(fname)
+            if args.print_errors:
+                print(str(e))
+
+
+if __name__ == '__main__':
+    arg_parser = ArgumentParser()
+    arg_parser.add_argument(
+        "-i", "--input", type=str, required=True,
+        help="Directory that will be parsed recursively."
+    )
+    arg_parser.add_argument(
+        "-o", "--output", type=str, required=True,
+        help="Directory where the output will be stored."
+    )
+    arg_parser.add_argument(
+        "-f", "--format", type=str, default="dot",
+        help="Output format, either `dot` (default) or `jsonl_gz`."
+    )
+    arg_parser.add_argument(
+        "--type-rules", type=str, default="../metadata/typingRules.json",
+        help="Path to json with type rules. Do not change, unless you extract data for type inference."
+    )
+    arg_parser.add_argument(
+        "--print-errors", action="store_true",
+        help="If passed, the errors for all failed files will be printed."
+    )
+    args = arg_parser.parse_args()
+    run(args)

--- a/src/data_preparation/scripts/requirements.txt
+++ b/src/data_preparation/scripts/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+matplotlib
+tqdm
+dpu_utils
+typed_ast


### PR DESCRIPTION
Add a script to run the graph extraction.

What it does:

Supports dot and jsonl.gz format
Tracks skipped and failed files (hopefully, there will be no failed files but still)
What it does not:

Does not have parallelization yet.